### PR TITLE
feat(api): env-gated Swagger docs and CORS

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -9,14 +9,18 @@ from restful_ressources import import_resources
 Base.metadata.create_all(bind=dbEngine)
 redis.init()
 
+_is_production = settings.APP_ENV == "production"
+
 app = FastAPI(
-    docs_url="/",
+    docs_url=None if _is_production else "/",
+    redoc_url=None if _is_production else "/redoc",
+    openapi_url=None if _is_production else "/openapi.json",
     title=settings.APP_TITLE,
     version=str(settings.APP_VERSION),
     description=settings.APP_DESCRIPTION,
 )
 
-if settings.APP_ENV == "local":
+if not _is_production:
     app.add_middleware(
         CORSMiddleware,
         allow_origins=["*"],


### PR DESCRIPTION
## Summary
Hide OpenAPI/Swagger in production and only enable permissive CORS outside production.

## Depends on
- #11 (pydantic-settings)

## Testing
- Set `APP_ENV=production` — `/` docs return 404
- Set `APP_ENV=local` — Swagger at `/` works

Made with [Cursor](https://cursor.com)