### PR TITLE
fix(auth): constant-time login and unified credential errors

### DIFF
--- a/src/controllers/auth.py
+++ b/src/controllers/auth.py
@@ -7,23 +7,18 @@ from fastapi.security import OAuth2PasswordRequestForm
 from sqlalchemy.orm import Session
 
 from constants.settings import settings
-from models.User import User
-from utils.security import create_access_token, verify_password
+from utils.security import authenticate_by_username_or_email, create_access_token
 
 
 def login_for_access_token(form_data: OAuth2PasswordRequestForm, db: Session):
     """Validate username/email + password and return a JWT token."""
-    user_name_or_email = form_data.username
-    if "@" in user_name_or_email:
-        user = db.query(User).filter(User.email == form_data.username).first()
-    else:
-        user = db.query(User).filter(User.username == form_data.username).first()
+    user = authenticate_by_username_or_email(form_data.username, form_data.password, db)
     if not user:
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid credentials")
-    if user.password is None:
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid credentials")
-    if not verify_password(form_data.password, user.password):
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid credentials")
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid credentials",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
     access_token_expires = timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES)
     access_token = create_access_token(
         data={"sub": user.email},

--- a/src/routes/admin/user.py
+++ b/src/routes/admin/user.py
@@ -1,6 +1,6 @@
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, status
+from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
 
 from controllers.admin.user import add_user, delete_user, update_user
@@ -29,6 +29,8 @@ def get_user_by_id(
     db: Session = Depends(get_db),
 ):
     user = db.query(User).filter(User.id == user_id).first()
+    if user is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
     return remove_password_from_user(user)
 
 

--- a/src/utils/security.py
+++ b/src/utils/security.py
@@ -14,6 +14,9 @@ crypting_algorithm = "sha256_crypt" if settings.JWT_ALGORITHM == "HS256" else "b
 
 pwd_context = CryptContext(schemes=[crypting_algorithm], deprecated="auto")
 
+# Pre-hashed password used when the user does not exist (timing-attack mitigation).
+DUMMY_HASH = pwd_context.hash("__mercury_timing_dummy__")
+
 
 def validate_email(email):
     if re.search(email_regex, email):
@@ -46,10 +49,33 @@ def create_access_token(data: dict, expires_delta: Union[timedelta, None] = None
     return encoded_jwt
 
 
+def _authenticate_user_record(user: User | None, password: str) -> User | None:
+    if user is None or user.password is None:
+        verify_password(password, DUMMY_HASH)
+        return None
+    if not verify_password(password, user.password):
+        return None
+    return user
+
+
+def authenticate_by_email(email: str, password: str, db) -> User | None:
+    user = db.query(User).filter(User.email == email).first()
+    return _authenticate_user_record(user, password)
+
+
+def authenticate_by_username_or_email(username_or_email: str, password: str, db) -> User | None:
+    if "@" in username_or_email:
+        return authenticate_by_email(username_or_email, password, db)
+    user = db.query(User).filter(User.username == username_or_email).first()
+    return _authenticate_user_record(user, password)
+
+
 def authenticate_user(payload, db):
-    user = db.query(User).filter(User.email == payload.email).first()
+    user = authenticate_by_email(payload.email, payload.password, db)
     if not user:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Invalid credentials")
-    if not verify_password(payload.password, user.password):
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Incorrect password")
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid credentials",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
     return user


### PR DESCRIPTION
## Summary
Prevent credential timing leaks and user-enumeration via error messages.

## Depends on
- #12 (env-gated docs) — merge chain from #11

## Changes
- DUMMY_HASH + verify on missing users
- Shared authenticate_by_email / authenticate_by_username_or_email
- Admin GET by id returns 404 when user missing

Made with [Cursor](https://cursor.com)