### PR TITLE
fix(auth): enforce disabled check on admin routes

### DIFF
--- a/src/middleware/auth_guard.py
+++ b/src/middleware/auth_guard.py
@@ -49,9 +49,9 @@ async def get_current_active_user(
 
 
 async def get_current_admin_user(
-    current_user: Annotated[User, Depends(get_current_user)],
+    current_user: Annotated[User, Depends(get_current_active_user)],
 ) -> User:
-    """Require that the current user is an admin."""
+    """Require that the current user is an active admin."""
     if current_user.is_admin is False:
         raise HTTPException(status_code=400, detail="User is not admin")
     return current_user


### PR DESCRIPTION
## Summary
Admin dependencies now require non-disabled users via get_current_active_user.

## Depends on
- #14

Made with [Cursor](https://cursor.com)